### PR TITLE
in to_protobuf(), do not set fields whose values are None

### DIFF
--- a/src/protodict.py
+++ b/src/protodict.py
@@ -167,7 +167,12 @@ def _dict_to_protobuf(pb, value, type_callable_map, strict):
         if field.type == FieldDescriptor.TYPE_ENUM and isinstance(input_value, six.string_types):
             input_value = _string_to_enum(field, input_value)
 
-        if input_value is not None:
+        if input_value is None:
+            try:
+                delattr(pb, field.name)
+            except AttributeError:
+                pass
+        else:
             setattr(pb, field.name, input_value)
 
     return pb

--- a/src/protodict.py
+++ b/src/protodict.py
@@ -167,7 +167,8 @@ def _dict_to_protobuf(pb, value, type_callable_map, strict):
         if field.type == FieldDescriptor.TYPE_ENUM and isinstance(input_value, six.string_types):
             input_value = _string_to_enum(field, input_value)
 
-        setattr(pb, field.name, input_value)
+        if input_value is not None:
+            setattr(pb, field.name, input_value)
 
     return pb
 


### PR DESCRIPTION
Unless I am mistaken, there is never a reason to set `None` in a field in a protobuf object.  I think that such a value should be treated as a missing field.

 Python 3's `Optional[ X ]` type hint is synonymous with `Union[ None, X ]`, as well, and `None` is often used in structured objects to indicate the lack of a field value (and, by extension, the field).

There is also no way to prevent some library object-to-dict conversion functions (e.g., `attr.asdict()` and `cattr.unstructure()`) from emitting `None`s.  So handling them would be useful.