### PR TITLE
Default to *not* base64 encoding byte fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,23 @@ Given the `google.protobuf.message.Message` subclass `MyMessage`:
 
 ## Caveats
 
+### Base64 encoded `bytes`
+
 This library grew out of the desire to serialize a protobuf-encoded message to
 [JSON](http://json.org/). As JSON has no built-in binary type (all strings in
-JSON are Unicode strings), any field whose type is
-`FieldDescriptor.TYPE_BYTES` is, by default, converted to a base64-encoded
-string.
+JSON are Unicode strings), a field whose type is `FieldDescriptor.TYPE_BYTES`
+should be converted to a base64-encoded string.
 
-If you want to override this behaviour, you may do so by passing
-`protobuf_to_dict` a dictionary of protobuf types to callables via the
-`type_callable_map` kwarg:
+If you want to encode bytes is this way, both `to_dict()` and `to_protobuf()`
+take an optional `base64_bytes` argument:
 
 ```python
->>> from copy import copy
->>> from google.protobuf.descriptor import FieldDescriptor
->>> from protodict import to_dict, TYPE_CALLABLE_MAP
->>>
->>> type_callable_map = copy(TYPE_CALLABLE_MAP)
->>> # convert TYPE_BYTES to a Python bytestring
->>> type_callable_map[FieldDescriptor.TYPE_BYTES] = str
->>>
 >>> # my_message is a google.protobuf.message.Message instance
->>> to_dict(my_message, type_callable_map=type_callable_map)
+>>> my_dict = to_dict(my_message, base64_bytes = True)
+>>> to_protobuf(my_dict, base64_bytes = True)
 ```
+
+### `int` vs. `str` enums
 
 By default, the integer representation is used for enum values. To use their
 string labels instead, pass `use_enum_labels=True` into `to_dict`:

--- a/src/tests/test_proto_to_dict.py
+++ b/src/tests/test_proto_to_dict.py
@@ -97,6 +97,14 @@ class Test(unittest.TestCase):
         m2 = to_protobuf(MessageOfTypes, d, strict=False)
         assert m == m2
 
+    def test_base64_bytes(self):
+        m = self.populate_MessageOfTypes()
+        d = to_dict(m, base64_bytes = True)
+        self.compare(m, d, ['nestedRepeated'], base64_bytes = True)
+
+        m2 = to_protobuf(MessageOfTypes, d, base64_bytes = True)
+        assert m == m2
+
     def populate_MessageOfTypes(self):
         m = MessageOfTypes()
         m.dubl = 1.7e+308
@@ -121,7 +129,7 @@ class Test(unittest.TestCase):
         m.range.extend(range(10))
         return m
 
-    def compare(self, m, d, exclude=None):
+    def compare(self, m, d, exclude = None, base64_bytes = False):
         i = 0
         exclude = ['byts', 'nested'] + (exclude or [])
         for i, field in enumerate(MessageOfTypes.DESCRIPTOR.fields): #@UndefinedVariable
@@ -129,7 +137,10 @@ class Test(unittest.TestCase):
                 assert field.name in d, field.name
                 assert d[field.name] == getattr(m, field.name), (field.name, d[field.name])
         assert i > 0
-        assert m.byts == base64.b64decode(d['byts'])
+        if base64_bytes:
+            assert m.byts == base64.b64decode(d['byts'])
+        else:
+            assert m.byts == d['byts']
         assert d['nested'] == {'req': m.nested.req}
 
     def test_extensions(self):


### PR DESCRIPTION
I understand the requirement to encode/decode base64 bytes fields. But I feel there is a good argument not to do this by default:
* Base64 encoding/decoding `bytes` fields is not sufficient to generate JSON-compatible `dict`s anyway. For example, the proto3 specs also specify field *name* conversions must take place.  E.g., a `num_wheels` field in a proto3 message should become a `numWheels` field in the JSON output. (See [JSON Mapping](https://developers.google.com/protocol-buffers/docs/proto3#json).)
* Python 3 has a `bytes` type which would be a more appropriate/pythonic type to use.
* If the facility to generate JSON (or a JSON-like `dict`, at least) is required, this functionality could be provided by a separate call, e.g., `to_json()`, which could internally set up a different `type_callable_map`. (In my view, expecting users of `protodict` to have to set up `type_callable_map` should probably be considered more of an advanced usage anyway.)